### PR TITLE
Provide an extended well-known names for filters

### DIFF
--- a/source/extensions/filters/http/basic_auth/BUILD
+++ b/source/extensions/filters/http/basic_auth/BUILD
@@ -24,6 +24,7 @@ envoy_cc_library(
     repository = "@envoy",
     deps = [
         ":basic_auth",
+        "//source/extensions/filters/http:well_known_names",
         "@envoy//source/exe:envoy_common_lib",
     ],
 )

--- a/source/extensions/filters/http/basic_auth/config.h
+++ b/source/extensions/filters/http/basic_auth/config.h
@@ -1,21 +1,22 @@
 #pragma once
 
+#include "source/extensions/filters/http/basic_auth/config.pb.h"
 #include "source/extensions/filters/http/basic_auth/config.pb.validate.h"
 
 #include "extensions/filters/http/common/factory_base.h"
+#include "extensions/filters/http/extended_well_known_names.h"
 
 namespace Envoy {
 namespace Extensions {
 namespace HttpFilters {
 namespace BasicAuth {
 
-static const std::string& BASIC_AUTH_FILTER() {
-  CONSTRUCT_ON_FIRST_USE(std::string, "diy.basic_auth");
-}
-
+/**
+ * Config registration for the basic auth filter. @see NamedHttpFilterConfigFactory.
+ */
 class BasicAuthFilterConfigFactory : public Common::FactoryBase<diy::BasicAuth> {
 public:
-  BasicAuthFilterConfigFactory() : FactoryBase(BASIC_AUTH_FILTER()) {}
+  BasicAuthFilterConfigFactory() : FactoryBase(ExtendedHttpFilterNames::get().BasicAuth) {}
 
 private:
   Http::FilterFactoryCb


### PR DESCRIPTION
This patch adds the extended well-known names for the HTTP filters
extensions. The class that provides the list of HTTP filter names is
ExtendedHttpFilterValues.

PS. Using the same class name leads to double registration problem.

Signed-off-by: Dhi Aurrahman <dio@rockybars.com>